### PR TITLE
BUG FIX : japanese charactors are garbled

### DIFF
--- a/includes/class-tei-dom.php
+++ b/includes/class-tei-dom.php
@@ -29,7 +29,7 @@ class TeiDom {
 
 
 	function __construct($sessionArray, $ops = array()) {
-		@apply_filters('init');
+		// @apply_filters('init');
 		//the anthologize filter echos content, which clobbers exports
 		remove_filter('the_content', 'anthologize_filter_post_content');
 		if(class_exists('Tidy')) {

--- a/includes/class-tei-dom.php
+++ b/includes/class-tei-dom.php
@@ -651,7 +651,7 @@ class TeiDom {
 		$tmpHTML = new DOMDocument('1.0', 'UTF-8');
 		//conceal the Warning about bad html with @
 		//loadHTML adds head and body tags silently
-		@$tmpHTML->loadHTML("<?xml version='1.0' encoding='UTF-8' ?><$element xmlns='http://www.w3.org/1999/xhtml'>$content</$element>" );
+		@$tmpHTML->loadHTML("<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"/></head><body><$element xmlns='http://www.w3.org/1999/xhtml'>$content</$element></body></html>" );
 		if($this->checkImgSrcs) {
 			$this->checkImageSources($tmpHTML);
 		}


### PR DESCRIPTION
Because DOMDocument::loadHTML method can not load japanese text in UTF-8 correctly without <meta> tag, I Added it.
