### PR TITLE
Project Organizer should only list public post types

### DIFF
--- a/includes/class-project-organizer.php
+++ b/includes/class-project-organizer.php
@@ -255,7 +255,9 @@ class Anthologize_Project_Organizer {
 	 * @return array A list of post type labels, keyed by name
 	 */
 	function available_post_types() {
-		$all_post_types = get_post_types( false, false );
+		$all_post_types = get_post_types( array(
+			'public' => true
+		), false );
 
 		$excluded_post_types = apply_filters( 'anth_excluded_post_types', array(
 			'anth_library_item',

--- a/includes/class-project-organizer.php
+++ b/includes/class-project-organizer.php
@@ -206,7 +206,7 @@ class Anthologize_Project_Organizer {
 				$types = $this->available_post_types();
 				$terms = array();
 				foreach ( $types as $type_id => $type_label ) {
-					$type_object = null;
+					$type_object = new stdClass;
 					$type_object->term_id = $type_id;
 					$type_object->name = $type_label;
 					$terms[] = $type_object;


### PR DESCRIPTION
When editing a project, under `Items > Filter by > Post Type`, all post types are listed in the `All post types` dropdown.

This PR restricts this dropdown menu to public post types only as private post types should not be listed.  Commit 49fac4d also fixes a warning.