### PR TITLE
when fetching posts for items, exclude drafts

### DIFF
--- a/includes/class-ajax-handlers.php
+++ b/includes/class-ajax-handlers.php
@@ -86,7 +86,8 @@ class Anthologize_Ajax_Handlers {
 			'post_type' => array_keys($this->project_organizer->available_post_types()),
 			'posts_per_page' => -1,
 			'orderby' => 'post_date',
-			'order' => 'DESC'
+			'order' => 'DESC',
+			'post_status' => array( 'publish', 'pending', 'future', 'private' ),
 		);
 
 		switch ( $filterby ) {

--- a/includes/class-ajax-handlers.php
+++ b/includes/class-ajax-handlers.php
@@ -87,7 +87,10 @@ class Anthologize_Ajax_Handlers {
 			'posts_per_page' => -1,
 			'orderby' => 'post_date',
 			'order' => 'DESC',
-			'post_status' => array( 'publish', 'pending', 'future', 'private' ),
+			'post_status' => apply_filters(
+				'anth_included_post_stasuses',
+				array( 'publish', 'pending', 'future', 'private' )
+			),
 		);
 
 		switch ( $filterby ) {

--- a/includes/class-ajax-handlers.php
+++ b/includes/class-ajax-handlers.php
@@ -87,10 +87,7 @@ class Anthologize_Ajax_Handlers {
 			'posts_per_page' => -1,
 			'orderby' => 'post_date',
 			'order' => 'DESC',
-			'post_status' => apply_filters(
-				'anth_included_post_stasuses',
-				array( 'publish', 'pending', 'future', 'private' )
-			),
+			'post_status' => $this->project_organizer->source_item_post_statuses(),
 		);
 
 		switch ( $filterby ) {

--- a/includes/class-project-organizer.php
+++ b/includes/class-project-organizer.php
@@ -863,6 +863,14 @@ class Anthologize_Project_Organizer {
 	 * @return array
 	 */
 	function source_item_post_statuses() {
+		/**
+		 * Status of posts to include in the project organizer.
+		 * Defaults to just published, pending, future and private.
+		 *
+		 * @since 0.7.8
+		 *
+		 * @param array $statuses statuses of posts/pages to include in the project organizer
+		 */
 		return apply_filters(
 			'anthologize_source_item_post_statuses',
 			array( 'publish', 'pending', 'future', 'private' )

--- a/includes/class-project-organizer.php
+++ b/includes/class-project-organizer.php
@@ -461,10 +461,7 @@ class Anthologize_Project_Organizer {
 			'posts_per_page' => -1,
 			'orderby' => 'post_title',
 			'order' => 'DESC',
-			'post_status' => apply_filters(
-				'anth_included_post_stasuses',
-				array( 'publish', 'pending', 'future', 'private' )
-			)
+			'post_status' => $this->source_item_post_statuses(),
 		);
 
 		$cfilter = isset( $_COOKIE['anth-filter'] ) ? $_COOKIE['anth-filter'] : false;
@@ -855,6 +852,21 @@ class Anthologize_Project_Organizer {
 		$url = add_query_arg( $query_args, admin_url( 'admin.php' ) );
 
 		return $url;
+	}
+
+	/**
+	 * Gets the post statuses of source items to show in the project organizer.
+     *
+     * @package Anthologize
+     * @since 0.7.8
+	 *
+	 * @return array
+	 */
+	function source_item_post_statuses() {
+		return apply_filters(
+			'anthologize_source_item_post_statuses',
+			array( 'publish', 'pending', 'future', 'private' )
+		);
 	}
 }
 

--- a/includes/class-project-organizer.php
+++ b/includes/class-project-organizer.php
@@ -460,7 +460,8 @@ class Anthologize_Project_Organizer {
 			'post_type' => array('post', 'page', 'anth_imported_item' ),
 			'posts_per_page' => -1,
 			'orderby' => 'post_title',
-			'order' => 'DESC'
+			'order' => 'DESC',
+			'post_status' => array( 'publish', 'pending', 'future', 'private' )
 		);
 
 		$cfilter = isset( $_COOKIE['anth-filter'] ) ? $_COOKIE['anth-filter'] : false;

--- a/includes/class-project-organizer.php
+++ b/includes/class-project-organizer.php
@@ -858,7 +858,7 @@ class Anthologize_Project_Organizer {
 	 * Gets the post statuses of source items to show in the project organizer.
      *
      * @package Anthologize
-     * @since 0.7.8
+     * @since 0.8.0
 	 *
 	 * @return array
 	 */
@@ -867,7 +867,7 @@ class Anthologize_Project_Organizer {
 		 * Status of posts to include in the project organizer.
 		 * Defaults to just published, pending, future and private.
 		 *
-		 * @since 0.7.8
+		 * @since 0.8.0
 		 *
 		 * @param array $statuses statuses of posts/pages to include in the project organizer
 		 */

--- a/includes/class-project-organizer.php
+++ b/includes/class-project-organizer.php
@@ -461,7 +461,10 @@ class Anthologize_Project_Organizer {
 			'posts_per_page' => -1,
 			'orderby' => 'post_title',
 			'order' => 'DESC',
-			'post_status' => array( 'publish', 'pending', 'future', 'private' )
+			'post_status' => apply_filters(
+				'anth_included_post_stasuses',
+				array( 'publish', 'pending', 'future', 'private' )
+			)
 		);
 
 		$cfilter = isset( $_COOKIE['anth-filter'] ) ? $_COOKIE['anth-filter'] : false;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -186,3 +186,4 @@ function anthologize_get_session_output_params() {
 
 	return $params;
 }
+


### PR DESCRIPTION
When fetching posts from the project organizer, exclude draft posts by default. Specifically, only include published, pending, future, and private posts.
Maybe we should only include published and private posts by default, though?
Or maybe we should have a group of checkboxes (or multi-select) to show all the post statuses to choose from?
This isn't really meant to be the final PR, this is mostly meant to just get the ball rolling.
