### PR TITLE
Don't use h3s for part/items.

### DIFF
--- a/css/project-organizer.css
+++ b/css/project-organizer.css
@@ -37,10 +37,21 @@ div.anthologize {
 	font-family: "Lucida Grande", Verdana, Arial, "Bitstream Vera Sans", sans-serif;
 }
 
-#project-organizer-frame h3 {
+#project-organizer-frame .part-item {
 	font-family: "Lucida Grande", Verdana, Arial, "Bitstream Vera Sans", sans-serif;
-	font-size: 9pt;
 	font-weight: bold;
+}
+
+.part-title,
+.part-title-header,
+.part-item-title {
+	font-size: 9pt;
+	line-height: 12pt;
+}
+
+.part h3,
+.item h3 {
+	margin: 0;
 }
 
 #anthologize-logo {
@@ -153,7 +164,7 @@ span.fromNewId {
 }
 
 /* Individual parts */
-.postbox h3.part-item {
+.postbox .part-item {
 	background: #cfdae9 !important;
 	color: #25589a !important;
 	text-shadow: none !important;
@@ -179,12 +190,13 @@ span.fromNewId {
 	top: 6px;
 }
 
-.part-item-buttons {
-	width: 280px;
-	text-align: right;
+.anth-buttons {
+	font-weight: bold;
 	position: absolute;
 	right: 8px;
+	text-align: right;
 	top: 6px;
+	width: 280px;
 }
 
 .part-title {

--- a/includes/class-project-organizer.php
+++ b/includes/class-project-organizer.php
@@ -121,7 +121,7 @@ class Anthologize_Project_Organizer {
 						<div class="handlediv" title="<?php _e( 'Click to toggle', 'anthologize' ) ?>"><br></div>
 						<h3 class="hndle">
 							<span><?php _e( 'Parts', 'anthologize' ) ?></span>
-							<div class="part-item-buttons button" id="new-part">
+							<div class="part-item-buttons button anth-buttons" id="new-part">
 								<a href="post-new.php?post_type=anth_part&project_id=<?php echo esc_attr( $this->project_id ) ?>&new_part=1"><?php _e( 'New Part', 'anthologize' ) ?></a>
 							</div>
 						</h3>
@@ -402,18 +402,19 @@ class Anthologize_Project_Organizer {
 				?>
 
 				<li class="part" id="part-<?php echo esc_html( $part_id ) ?>">
-					<h3 class="part-header">
-						<noscript><a href="admin.php?page=anthologize&action=edit&project_id=<?php echo esc_attr( $this->project_id ) ?>&move_up=<?php echo esc_attr( $part_id ) ?>">&uarr;</a> <a href="admin.php?page=anthologize&action=edit&project_id=<?php echo esc_attr( $this->project_id ) ?>&move_down=<?php echo esc_attr( $part_id ) ?>">&darr;</a> </noscript>
-						<span class="part-title-header"><?php the_title() ?></span>
+					<div class="part-header">
+						<h3 class="part-title-header">
+							<noscript><a href="admin.php?page=anthologize&action=edit&project_id=<?php echo esc_attr( $this->project_id ) ?>&move_up=<?php echo esc_attr( $part_id ) ?>">&uarr;</a> <a href="admin.php?page=anthologize&action=edit&project_id=<?php echo esc_attr( $this->project_id ) ?>&move_down=<?php echo esc_attr( $part_id ) ?>">&darr;</a> </noscript>
+							<span class="part-title-header"><?php the_title() ?></span>
+						</h3>
 
-						<div class="part-buttons">
+						<div class="part-buttons anth-buttons">
 							<a href="post.php?post=<?php the_ID() ?>&action=edit&return_to_project=<?php echo esc_attr( $this->project_id ) ?>"><?php _e( 'Edit', 'anthologize' ) ?></a> |
 							<a target="_blank" href="<?php echo esc_url( $this->preview_url( get_the_ID(), 'anth_part' ) ) ?>" class=""><?php _e( 'Preview', 'anthologize' ) ?></a> |
 							<a href="admin.php?page=anthologize&action=edit&project_id=<?php echo esc_attr( $this->project_id ) ?>&remove=<?php the_ID() ?>" class="remove"><?php _e( 'Remove', 'anthologize' ) ?></a> |
 							<a href="#collapse" class="collapsepart"> - </a>
 						</div>
-
-					</h3>
+					</div>
 
 					<div class="part-items">
 						<ul>
@@ -516,7 +517,12 @@ class Anthologize_Project_Organizer {
 		?>
 			<ul id="sidebar-posts">
 				<?php while ( $big_posts->have_posts() ) : $big_posts->the_post(); ?>
-					<li class="item"><span class="fromNewId">new-<?php the_ID() ?></span><h3 class="part-item"><?php the_title() ?></h3></li>
+					<li class="part-item item">
+						<span class="fromNewId">new-<?php the_ID() ?></span><h3 class="part-item-title"><?php the_title() ?></h3>
+						<?php /*
+						<a href="#" class="hide-if-no-js">&#x25BC;</a>
+						*/ ?>
+					</li>
 				<?php endwhile; ?>
 			</ul>
 		<?php
@@ -800,7 +806,7 @@ class Anthologize_Project_Organizer {
 
 		?>
 
-		<li id="item-<?php the_ID() ?>" class="item">
+		<li id="item-<?php the_ID() ?>" class="part-item item">
 
 			<?php if ( $append_parent ) : ?>
 				<input type="checkbox" name="append_children[]" value="<?php the_ID() ?>" <?php if ( $append_parent == $post->ID ) echo 'checked="checked" disabled=disabled'; ?>/> <?php echo esc_html( $post->ID ) . " " . esc_html( $append_parent ) ?>
@@ -810,10 +816,10 @@ class Anthologize_Project_Organizer {
 				<a href="admin.php?page=anthologize&action=edit&project_id=<?php echo esc_attr( $this->project_id ) ?>&move_up=<?php the_ID() ?>">&uarr;</a> <a href="admin.php?page=anthologize&action=edit&project_id=<?php echo esc_attr( $this->project_id ) ?>&move_down=<?php the_ID() ?>">&darr;</a>
 			</noscript>
 
-			<h3 class="part-item">
+			<h3 class="part-item-title">
 				<span class="part-title"><?php the_title() ?></span>
 
-				<div class="part-item-buttons">
+				<div class="part-item-buttons anth-buttons">
 					<a href="post.php?post=<?php the_ID() ?>&action=edit&return_to_project=<?php echo esc_attr( $this->project_id ) ?>"><?php _e( 'Edit', 'anthologize' ) ?></a> |
 
 					<?php /* Comments are being pushed to a further release */ ?>

--- a/js/anthologize-sortlist.js
+++ b/js/anthologize-sortlist.js
@@ -251,7 +251,7 @@ var anthologize = {
 			'</div>';
 	*/
 
-	var buttons = 	'<div class="part-item-buttons">' +
+	var buttons = 	'<div class="part-item-buttons anth-buttons">' +
 				'<a href="post.php?post=' + new_item_id + '&amp;action=edit">' + anth_strings.edit + '</a> | ' +
 				'<a class="append" href="#append">' + anth_strings.append + '</a><span class="append-sep toggle-sep"> | </span>' +
 				'<a class="anth-preview anth-preview-item" href="admin.php?page=anthologize&anth_preview=1&post_type=anth_library_item&post_id=' + new_item_id + '" target="new">' + anth_strings.preview + '</a><span class="toggle-sep"> | </span>' +

--- a/js/project-organizer.js
+++ b/js/project-organizer.js
@@ -58,7 +58,7 @@
 			success: function(response){
 				j('#sidebar-posts').empty();
 				j.each( response, function(post_id, post_title) {
-					var h = '<li class="item"><span class="fromNewId">new-' + post_id + '</span><h3 class="part-item">' + post_title + '</h3></li>';
+					var h = '<li class="item part-item"><span class="fromNewId">new-' + post_id + '</span><h3 class="part-item-title">' + post_title + '</h3></li>';
 					j('#sidebar-posts').append(h);
 				});
 				anthologize.initSidebar();


### PR DESCRIPTION
The current markup for part/item draggable headers is not ideal. Everything, including the "buttons" (action links like 'Delete'), is wrapped in an `h3`. This is semantically incorrect, and it makes it hard to add new functionality to the part/item headers.

Instead, the h3 should contain just the title, with the drag/drop logic connected to the `li` elements.