### PR TITLE
Show source item details when browsing posts on project organizer.

### DIFF
--- a/anthologize.php
+++ b/anthologize.php
@@ -325,6 +325,7 @@ class Anthologize {
 			'comments_explain' => __( 'Check the comments from the original post that you would like to include in your project.', 'anthologize' ),
 			'done'             => __( 'Done', 'anthologize' ),
 			'edit'             => __( 'Edit', 'anthologize' ),
+			'hide_details'     => __( 'Hide details', 'anthologize' ),
 			'less'             => __( 'less', 'anthologize' ),
 			'more'             => __( 'more', 'anthologize' ),
 			'no_comments'      => __( 'This post has no comments associated with it.', 'anthologize' ),
@@ -334,6 +335,7 @@ class Anthologize {
 			'save'             => __( 'Save', 'anthologize' ),
 			'select_all'       => __( 'Select all', 'anthologize' ),
 			'select_none'      => __( 'Select none', 'anthologize' ),
+			'show_details'     => __( 'Show details', 'anthologize' ),
 		) );
 	}
 }

--- a/css/project-organizer.css
+++ b/css/project-organizer.css
@@ -199,6 +199,41 @@ span.fromNewId {
 	width: 280px;
 }
 
+#sidebar-posts .part-item-title {
+	margin-right: 10px;
+}
+
+.accordion-toggle {
+	cursor: pointer;
+	position: absolute;
+	right: 5px;
+	top: 5px;
+}
+
+.accordion-toggle-glyph:before {
+	content: '\2212';
+	display: block;
+	height: 10px;
+	width: 10px;
+}
+
+.accordion-closed .accordion-toggle-glyph:before {
+	content: '\002B';
+}
+
+.accordion-closed .item-details {
+	display: none;
+}
+
+.item-details {
+	background: #fff;
+	border-radius: 3px;
+	color: #000;
+	font-weight: normal;
+	margin-top: 1em;
+	padding: 5px;
+}
+
 .part-title {
 	padding-right: 290px;
 	display: block;

--- a/includes/class-project-organizer.php
+++ b/includes/class-project-organizer.php
@@ -517,11 +517,61 @@ class Anthologize_Project_Organizer {
 		?>
 			<ul id="sidebar-posts">
 				<?php while ( $big_posts->have_posts() ) : $big_posts->the_post(); ?>
-					<li class="part-item item">
-						<span class="fromNewId">new-<?php the_ID() ?></span><h3 class="part-item-title"><?php the_title() ?></h3>
-						<?php /*
-						<a href="#" class="hide-if-no-js">&#x25BC;</a>
-						*/ ?>
+					<?php
+					$item_metadata = array(
+						'link'   => sprintf(
+							'<a href="%s">%s</a>',
+							esc_attr( get_permalink() ),
+							esc_html__( 'View post', 'anthologize' )
+						),
+					);
+
+					$item_post   = get_post( get_the_ID() );
+					$item_author = get_userdata( $item_post->post_author );
+					$item_tags   = get_the_term_list( get_the_ID(), 'post_tag', '', ', ' );
+					$item_cats   = get_the_term_list( get_the_ID(), 'category', '', ', ' );
+
+					if ( $item_author ) {
+						$item_metadata['author'] = sprintf(
+							__( 'Author: %s', 'anthologize' ),
+							esc_html( sprintf( '%s (%s)', $item_author->display_name, $item_author->user_login ) )
+						);
+					}
+
+					if ( $item_tags ) {
+						$item_metadata['tags'] = sprintf( __( 'Tags: %s', 'anthologize' ), $item_tags );
+					}
+
+					if ( $item_cats ) {
+						$item_metadata['cats'] = sprintf( __( 'Categories: %s', 'anthologize' ), $item_cats );
+					}
+
+					/**
+					 * Filters the metadata shown below a post item in the project organizer.
+					 *
+					 * @since 0.8.0
+					 *
+					 * @param array $item_metadata Metadata assembled by Anthologize.
+					 * @param int   $item_id       ID of the post.
+					 */
+					$item_metadata = apply_filters( 'anthologize_source_item_metadata', $item_metadata, get_the_ID() );
+
+					?>
+					<li class="part-item item has-accordion accordion-closed">
+						<span class="fromNewId">new-<?php the_ID() ?></span>
+						<h3 class="part-item-title"><?php the_title() ?></h3>
+						<span class="accordion-toggle hide-if-no-js">
+							<span class="accordion-toggle-glyph"></span>
+							<span class="screen-reader-text"><?php esc_html_e( 'Show details', 'anthologize' ); ?></span>
+						</span>
+
+						<div class="item-details">
+							<ul>
+							<?php foreach ( $item_metadata as $im ) : ?>
+								<li><?php echo $im; ?></li>
+							<?php endforeach; ?>
+							</ul>
+						</div>
 					</li>
 				<?php endwhile; ?>
 			</ul>

--- a/js/anthologize-sortlist.js
+++ b/js/anthologize-sortlist.js
@@ -597,6 +597,10 @@ jQuery(document).ready(function(){
 		anthologize.toggleCollapseCookie(part.attr('id'));
 	});
 
+	jQuery('#project-organizer-frame').on('click', '.accordion-toggle', function( e ) {
+		jQuery(e.target).closest('.has-accordion').toggleClass('accordion-closed');
+	} );
+
 	var cp = jQuery.cookie('collapsedparts');
 	if (cp){
 		var parts = cp.split(',');


### PR DESCRIPTION
Had a client request to show more data about source items when browsing on the project organizer. This seems like a nearly universally useful thing, so here's the feature in the form of a PR. See screenshot:

![screenshot_2018-11-19_15-50-52](https://user-images.githubusercontent.com/246627/48737236-212e0d00-ec13-11e8-8d99-8f96f052db0c.png)

The little plus sign is a toggle that shows/hides the "details". The details shown are the 'View post' link; the author info; a tag list (if there are tags); a category list (if there are categories). This metadata is run through a filter so that plugins can modify. I put it against a white background because the existing background colors made it very hard to read (and didn't pass a11y checks).