### PR TITLE
Use source item author names to generate default project author string.

### DIFF
--- a/includes/class-export-panel.php
+++ b/includes/class-export-panel.php
@@ -75,12 +75,14 @@ class Anthologize_Export_Panel {
 		// No default for edition number
 		$edition = isset( $options['edition'] ) ? isset( $options['edition'] ) : false;
 
-		if ( isset( $options['authors'] ) )
+		if ( isset( $options['authors'] ) ) {
 			$authors = $options['authors'];
-		else if ( isset( $options['author_name'] ) )
+		} elseif ( isset( $options['author_name'] ) ) {
 			$authors = $options['authors'];
-		else
-			$authors = '';
+		} else {
+			$author_names = anthologize_get_item_author_names( $project_id );
+			$authors = implode( ', ', $author_names );
+		}
 
 		$dedication = !empty( $options['dedication'] ) ? $options['dedication'] : '';
 
@@ -156,8 +158,11 @@ class Anthologize_Export_Panel {
 				</tr>
 
 				<tr valign="top">
-					<th scope="row"><label for="authors"><?php _e( 'Add Author(s)', 'anthologize' ) ?></label></th>
-					<td><textarea id="authors" name="authors"><?php echo esc_textarea( $authors ); ?></textarea></td>
+					<th scope="row"><label for="authors"><?php esc_html_e( 'Author(s)', 'anthologize' ) ?></label></th>
+					<td>
+						<textarea id="authors" name="authors"><?php echo esc_textarea( $authors ); ?></textarea>
+						<p class="description">The default value is automatically compiled, based on authors of the source content.</p>
+					</td>
 				</tr>
 			</table>
 

--- a/includes/class-new-project.php
+++ b/includes/class-new-project.php
@@ -161,11 +161,6 @@ class Anthologize_New_Project {
                     <td><input type="text" name="anthologize_meta[subtitle]" id="project-subtitle" value="<?php if( $project && !empty($meta['subtitle']) ) echo esc_attr( $meta['subtitle'] ); ?>" /></td>
                 </tr>
 
-				<tr valign="top">
-					<th scope="row"><label for="project-author"><?php _e( 'Author Name <span>(optional)</span>', 'anthologize' ) ?></label></th>
-					<td><textarea name="anthologize_meta[author_name]" id="project-author" rows="5" cols="50"><?php if( $project && !empty($meta['author_name']) ) echo esc_textarea( $meta['author_name'] ); ?></textarea></td>
-				</tr>
-
 				<?php /* Hidden until there is a more straightforward way to display projects on the front end of WP */ ?>
 				<?php /*
             	<tr valign="top">

--- a/templates/pdf/class-pdf-anthologizer.php
+++ b/templates/pdf/class-pdf-anthologizer.php
@@ -120,14 +120,16 @@ class PdfAnthologizer extends Anthologizer {
 
 		$this->frontPages++;
 
-		$this->output->SetY(80);
-		$this->output->Write('', $book_title, '', false, 'C', true );
-		$this->output->setFont($this->font_family, '', $this->baseH);
+		$this->output->SetY( 80 );
 
+		$table = '<table><tr><td align="center">' . $book_title . '</td></tr></table>';
+		$this->output->writeHTML( $table );
+
+		$this->output->setFont($this->font_family, '', $this->baseH);
 
 		switch($this->api->getProjectOutputParams('creatorOutputSettings')) {
 		    case ANTHOLOGIZE_CREATORS_ALL:
-		        $projectAuthorsString = $creator . ', ' . $assertedAuthors;
+		        $projectAuthorsString = $assertedAuthors;
 		        break;
 
 		    case ANTHOLOGIZE_CREATORS_ASSERTED:
@@ -138,11 +140,15 @@ class PdfAnthologizer extends Anthologizer {
 		        break;
 		}
 
-
-		$this->output->Write('', $projectAuthorsString, '', false, 'C', true );
-		$this->output->SetY(120);
 		$year = substr( $this->api->getProjectPublicationDate(), 0, 4 );
-		$this->output->Write('', $this->api->getProjectCopyright(false, false) . ' -- ' . $year , '', false, 'C', true );
+
+		$table  = '<table cellpadding="5">';
+		$table .= '<tr><td align="center">' . $projectAuthorsString . '</td></tr>';
+		$table .= '<tr><td align="center">' . $this->api->getProjectCopyright( false, false ) . ' &mdash; ' . $year . '</td></tr>';
+		$table .= '</table>';
+
+		$this->output->writeHTML( $table );
+
         $this->output->EndPage();
 
 		//dedication


### PR DESCRIPTION
The 'Author(s)' field on the Export Project panel is now prefilled
with a comma-separated list of the display names belonging to the authors
of the source content. This can then be modified by the exporter.

As part of this change, the formatting of author info in PDF output
has been improved, to ensure centering of long text.

The impetus here is that the project "author" should generally reflect the author of the constituent parts. This info is hard to assemble manually, so we probably help lots of users by suggesting it automatically. For those projects where it's not appropriate (where 'author' should be an editor name or something) it's still easy for the user to customize at the time of export.