### PR TITLE
Fix unsupported `e` modifier in `preg_replace()`

### DIFF
--- a/templates/rtf/class-rtf-anthologizer.php
+++ b/templates/rtf/class-rtf-anthologizer.php
@@ -473,8 +473,21 @@ class RtfAnthologizer extends Anthologizer {
     // Now replace HTML entities with RTF \uxxx notation
     // Code derived from http://php.net/manual/en/function.html-entity-decode.php
 
-    $data = preg_replace('~&#x([0-9a-f]+);~ei', '"\\u" . hexdec("\\1")', $data);  // Hex
-    $data = preg_replace('~&#([0-9]+);~e',      '"\\u\\1"',              $data);  // Dec
+    // Convert hex entities to RTF unicode notation
+    $data = preg_replace_callback( '~&#x([0-9a-f]+);~i',
+        function($matches) {
+            return '\\u' . hexdec($matches[1]);
+        },
+        $data
+    );
+
+    // Convert decimal entities to RTF unicode notation
+    $data = preg_replace_callback('~&#([0-9]+);~',
+        function($matches) {
+            return '\\u' . $matches[1];
+        },
+        $data
+    );
 
     // Replace literal entities
 


### PR DESCRIPTION
As of PHP 7.0, `preg_replace()` has not supported the `e` modifier and will return a `null` value in this spot.

This uses `preg_replace_callback()` to process the string in a callback function rather than via an `eval()` attempt.

I don't think this is super critical, as it has been removed since PHP 7.0, but it appears to possibly have an impact on HTML to RTF conversion.

See https://3v4l.org/VaBm7 for an example of the text processed here.